### PR TITLE
Reduced opacity for "File Colors" UI theme keys

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -124,12 +124,12 @@
       "underlineColor": "#88c0d0"
     },
     "FileColor": {
-      "Blue": "#88c0d0",
-      "Green": "#a3be8c",
-      "Orange": "#d08770",
-      "Rose": "#bf616a",
-      "Violet": "#b48ead",
-      "Yellow": "#ebcb8b"
+      "Blue": "#88c0d01a",
+      "Green": "#a3be8c1a",
+      "Orange": "#d087701a",
+      "Rose": "#bf616a1a",
+      "Violet": "#b48ead1a",
+      "Yellow": "#ebcb8b1a"
     },
     "Group": {
       "disabledSeparatorColor": "#3b4252"


### PR DESCRIPTION
> Resolves #47 

The [File Colors][fc] are used to distingush between project files, folders or packages of specific scopes. Unfortunately the theme API doesn't allow (yet) to specify the target for the color like e.g. background or only foreground.
With the previous colors (100% opacity) this resulted in too bright highlighted backgrounds making most labels unreadable and destroying the themes overall appearance.

They color's opacity has now been changed to 10% which is still enough to be recognizable and doesn't affects the readability of labels.

#### Before

<p align="center"><img src="https://user-images.githubusercontent.com/7836623/58237656-f0579d80-7d45-11e9-9d6a-9ae9923299c5.png"></p>

<p align="center"><img src="https://user-images.githubusercontent.com/7836623/58237738-1e3ce200-7d46-11e9-8364-6ce1fc8352eb.png"></p>

#### After

<p align="center"><img src="https://user-images.githubusercontent.com/7836623/58237729-18df9780-7d46-11e9-8092-78aa51fe5837.png"></p>

<p align="center"><img src="https://user-images.githubusercontent.com/7836623/58237667-f5b4e800-7d45-11e9-9fe1-9f40c2328b9e.png"></p>

[fc]: https://www.jetbrains.com/help/idea/settings-file-colors.html