### PR TITLE
Editor Notification Background Color

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -42,7 +42,7 @@
     <option name="LINE_NUMBERS_COLOR" value="4c566a" />
     <option name="METHOD_SEPARATORS_COLOR" value="d8dee9" />
     <option name="MODIFIED_LINES_COLOR" value="ebcb8b" />
-    <option name="NOTIFICATION_BACKGROUND" value="d8dee9" />
+    <option name="NOTIFICATION_BACKGROUND" value="4c566a" />
     <option name="QUESTION_HINT" value="434c5e" />
     <option name="RECURSIVE_CALL_ATTRIBUTES" value="" />
     <option name="RIGHT_MARGIN_COLOR" value="4c566a" />


### PR DESCRIPTION
> Resolves #52 

Before the new UI theme API was released the editor color scheme provided multiple theme keys to also style some UI elements like the editor notifications ([`NOTIFICATION_BACKGROUND`][key-def] like also defined in the [default bundled Darcula editor color scheme][decs]).
The key allows to style the background color of notifications from the editor that are placed right below the tab bar at the top of the editor.

Previously `nord4` was used that made the color almost unreadable because by default a low contrast foreground is used.
This has now been changed to use `nord3` making the actual text content readable again.

<p align="center"><strong>Before</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59462569-4c34b400-8e24-11e9-9551-b1cc9a29ce22.png"></p>

<p align="center"><strong>After</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59462619-71c1bd80-8e24-11e9-90a8-fe33f94b08a7.png"></p>

[key-def]: https://github.com/JetBrains/intellij-community/blob/33f568ba94669047ac2bb4782f3a27d5008680fa/platform/editor-ui-api/src/com/intellij/openapi/editor/colors/EditorColors.java#L46
[decs]: https://github.com/JetBrains/intellij-community/blob/master/platform/platform-resources/src/DefaultColorSchemesManager.xml#L1230