### PR TITLE
Improve style for lines with both syntax and code inspection errors

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -759,10 +759,10 @@
     </option>
     <option name="ERRORS_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="d8dee9" />
-        <option name="BACKGROUND" value="bf616a" />
+        <option name="FOREGROUND" value="bf616a" />
+        <option name="EFFECT_COLOR" value="bf616a" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
-        <option name="EFFECT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
     <option name="EXECUTIONPOINT_ATTRIBUTES">
@@ -1705,7 +1705,7 @@
         <option name="FOREGROUND" value="bf616a" />
         <option name="EFFECT_COLOR" value="bf616a" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
-        <option name="EFFECT_TYPE" value="4" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME" baseAttributes="DEFAULT_ATTRIBUTE" />


### PR DESCRIPTION
> Resolves #60 

A line that contained both a syntax error as well as a _IntelliJ Code Inspection_ (`ERRORS_ATTRIBUTES` editor scheme key) error was unreadable because both error detection scopes/types applied their different highlighting styles resulting in a background and foreground color colorized with `nord11`. This made it impossible to read the text.

<p align="center">Highlighting resulting in unreadable text when combined with error text</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59548537-20fbb300-8f51-11e9-98b3-ed48888f4978.png"></p>

Some tests using a opacity of 60% for `nord11` as background color instead resulted in a “dirty redish“ color due to the miy with the base editor background color.

<p align="center">Reduced opacity of 60%</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59513773-d1b77300-8ebb-11e9-95d8-ddb86a988c82.png"></p>

Therefore a better style of highlighting these errors has been designed.
The new style doesn't make use of a background color at all based on the fact that it is a duplicate highlighting. If there's a syntax error the invalid tokens will be highlighted with `nord11` due to the syntax error so there is no need to additionally colorize the background with `nord11` which is the main reason for the unreadable text.

The new styles for _Code Inspection_ errors has been simplified to use `nord11` as foreground color with a bold underline and the already used error stripe next to the line numbers. This design decision also comes with a change for the “Unknown Symbol“ highlighting (`WRONG_REFERENCES_ATTRIBUTES` color scheme key) that now uses a dotted underline instead to differentiate from the new error styles.

<p align="center">Improved error and <em>Unknown Symbol</em> styles</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59548550-556f6f00-8f51-11e9-8270-5eff1fc7863a.png"></p>
