### PR TITLE
Styles for deprecated symbols marked for removal

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1307,6 +1307,12 @@
         <option name="FOREGROUND" value="4c566a" />
       </value>
     </option>
+    <option name="MARKED_FOR_REMOVAL_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="bf616a" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="434c5e" />


### PR DESCRIPTION
> Resolves #63 

The “General“ editor scheme section provides a option to style _deprecated symbols that are marked for removal_.
The new `MARKED_FOR_REMOVAL_ATTRIBUTES` key has been added using a `strikethrough` effect style colorized with `nord11` to draw more attention to such elements.

<p align="center"><img src="https://user-images.githubusercontent.com/7836623/59548762-260e3180-8f54-11e9-90c7-ec5a6a4ce92b.png"></p>
