### PR TITLE
Go syntax highlighting support for IntelliJ/Goland 2019.2

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -829,23 +829,57 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
+    <option name="GO_BAD_TOKEN">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="GO_BLOCK_COMMENT" baseAttributes="DEFAULT_BLOCK_COMMENT" />
+    <option name="GO_BUILTIN_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
     <option name="GO_BUILTIN_TYPE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="GO_LOCAL_CONSTANT">
+    <option name="GO_BUILTIN_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="GO_EXPORTED_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
+    <option name="GO_EXPORTED_INTERFACE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="GO_LINE_COMMENT" baseAttributes="DEFAULT_LINE_COMMENT" />
+    <option name="GO_LOCAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="GO_LOCAL_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
+    <option name="GO_METHOD_RECEIVER" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
+    <option name="GO_PACKAGE" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="GO_PACKAGE_EXPORTED_CONSTANT">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="GO_PACKAGE_EXPORTED_CONSTANT">
+    <option name="GO_PACKAGE_EXPORTED_VARIABLE">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
-        <option name="FONT_TYPE" value="3" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_TYPE_REFERENCE" baseAttributes="DEFAULT_CLASS_REFERENCE" />
     <option name="GRID_ERROR_VALUE">
       <value>
         <option name="FOREGROUND" value="bf616a" />


### PR DESCRIPTION
> Resolves #69 

IntelliJ/Goland version 2019.2 [introduced support for 20+ languages][rl] out-of-the-box by integrating [TextMate][tm] schemes.
Unfortunately this resulted in a change for existing theme definition where some editor color scheme keys that previously inherited the best matching global key now used the attributes defined by the parent theme _Darcula_. Therefore Nord's highlighting for Go broke and required to explicitly define the values for some attributes in order to achieve the same highlight like in previous versions that are matching Nord's style guidelines.

<p align="center">Before</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62239717-b81fab80-b3d5-11e9-8e17-3b9d7fe3424e.png" /></p>

<p align="center">After</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62239716-b81fab80-b3d5-11e9-9280-7829faea4370.png" /></p>

[rl]: https://www.jetbrains.com/idea/whatsnew/#v2019-2-editor
[tm]: https://macromates.com
