### PR TITLE
Use `nord8` for Markdown link titles

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1293,7 +1293,7 @@
     </option>
     <option name="MARKDOWN_LINK_TEXT">
       <value>
-        <option name="FOREGROUND" value="a3be8c" />
+        <option name="FOREGROUND" value="88c0d0" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>


### PR DESCRIPTION
> Resolves #79 

<p align="center">Before</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62284066-33737280-b453-11e9-9f26-5146eeb3ef62.png"/></p>

<p align="center">After</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62284065-33737280-b453-11e9-9eaa-658ce5e1350c.png"/></p>