### PR TITLE
Normal styles for TypeScript "type guarded" variables

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1645,6 +1645,11 @@
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="TS.TYPE_GUARD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="TS.TYPE_PARAMETER">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />


### PR DESCRIPTION
> Resolves #81 

<p align="center">Before</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62284838-b77a2a00-b454-11e9-85f2-fba1a3f52304.png"/></p>

<p align="center">After</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62284837-b77a2a00-b454-11e9-8eea-d12f2e611a73.png"/></p>
