### PR TITLE
Python Plugin (PyCharm Professional Edition) Support

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1032,6 +1032,22 @@
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
+    <option name="JUPYTER_CELL_MARKER">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JUPYTER_INLINE_VALUES">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JUPYTER_SELECTED_CELL">
+      <value>
+        <option name="EFFECT_COLOR" value="d8dee9" />
+      </value>
+    </option>
     <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES" />
     <option name="KOTLIN_BACKING_FIELD_VARIABLE">
       <value />
@@ -1205,6 +1221,7 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="MAKO.SUBSTITUTION" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
     <option name="MARKDOWN_BLOCK_QUOTE">
       <value>
         <option name="FOREGROUND" value="616e88" />
@@ -1366,21 +1383,44 @@
         <option name="FOREGROUND" value="d08770" />
       </value>
     </option>
-    <option name="PY.BUILTIN_NAME">
-      <value>
-        <option name="FOREGROUND" value="88c0d0" />
-      </value>
-    </option>
-    <option name="PY.CLASS_DEFINITION">
+    <option name="PY.ANNOTATION">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
-        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="PY.BUILTIN_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
     <option name="PY.DECORATOR">
       <value>
         <option name="FOREGROUND" value="d08770" />
-        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.FSTRING_FRAGMENT_BRACES">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="PY.FSTRING_FRAGMENT_COLON">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER" />
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="PY.SELF_PARAMETER">
@@ -1388,6 +1428,7 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
+    <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING" />
     <option name="QL_FUNCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />


### PR DESCRIPTION
> Resolves #35 

Added support for the [official Python plugin][plug] that adds syntax highlighting for Python as well as [Jupyter][j] and [Mako Templates][m] and is equal to the [PyCharm Professional Edition][pyc].

### Previews

#### Before 

<p align="center"><strong>Python</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292274-6410d780-b466-11e9-968e-3887719ca335.png"/></p>

<p align="center"><strong>Jupyter</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292272-63784100-b466-11e9-9805-d68cac0d32a8.png"/></p>

<p align="center"><strong>Mako Templates</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292273-63784100-b466-11e9-88d1-5313754c46be.png"/></p>

#### After 

<p align="center"><strong>Python</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292333-7db21f00-b466-11e9-9e2e-2f323e96b7cc.png"/></p>

<p align="center"><strong>Jupyter</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292331-7d198880-b466-11e9-9a5a-beb4bafb1d55.png"/></p>

<p align="center"><strong>Mako Templates</strong></p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62292332-7db21f00-b466-11e9-93f2-e6526b12d428.png"/></p>

[plug]: https://plugins.jetbrains.com/plugin/631-python
[j]: https://jupyter.org
[m]: https://www.makotemplates.org
[pyc]: https://www.jetbrains.com/pycharm