### PR TITLE
Fix unreadable completion popup list items in non-focused state

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -83,7 +83,6 @@
       "background": "#323846",
       "matchForeground": "#88c0d0",
       "matchSelectionForeground": "#88c0d0",
-      "nonFocusedMask": "#2e3440",
       "nonFocusedState": "#2e3440",
       "selectionBackground": "#4c566a",
       "selectionInactiveBackground": "#3b4252",


### PR DESCRIPTION
> Fixes #88 

In [v0.8.0][] some new UI theme keys have been added and deprecated ones modified or removed through #86 and PR #87. This included the `ui.CompletionPopup.nonFocusedMask` key that has been set to `nord0` without a alpha layer value. Since the auto completion popup of IntelliSense if not focused but the editor itself, the overlay mask gets applied. As soon as the up or down arrow keys are pressed the popup gets the focus and therefore the mask gets removed showing the list items with correct styles.

The key has been removed, the popup should be shown the same like in focused state for better readable text and easy recognition of the desired auto complete entry.

<p align="center">Before</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62409939-e3291b80-b5de-11e9-8367-53670c0ca0f1.gif" /></p>

<p align="center">After</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62410003-01434b80-b5e0-11e9-9328-4aa120b2eb01.gif" /></p>

[v0.8.0]: https://github.com/arcticicestudio/nord-jetbrains/releases/tag/v0.8.0