### PR TITLE
Go syntax highlighting support for IntelliJ/Goland 2019.3

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -2,8 +2,8 @@
   <metaInfo>
     <property name="created">2016-09-24T21:08:20</property>
     <property name="ide">idea</property>
-    <property name="ideVersion">2019.1.0.0</property>
-    <property name="modified">2019-04-18T15:14:45</property>
+    <property name="ideVersion">2019.3.0.0</property>
+    <property name="modified">2019-12-02T09:34:36</property>
     <property name="originalScheme">Nord</property>
   </metaInfo>
   <colors>
@@ -843,13 +843,21 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="GO_BLOCK_COMMENT" baseAttributes="DEFAULT_BLOCK_COMMENT" />
+    <option name="GO_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
     <option name="GO_BUILTIN_CONSTANT">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="GO_BUILTIN_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
+    <option name="GO_BUILTIN_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="GO_BUILTIN_TYPE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
@@ -861,20 +869,52 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="GO_EXPORTED_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
-    <option name="GO_EXPORTED_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
+    <option name="GO_EXPORTED_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="GO_EXPORTED_INTERFACE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="GO_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="GO_LINE_COMMENT" baseAttributes="DEFAULT_LINE_COMMENT" />
-    <option name="GO_LOCAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
-    <option name="GO_LOCAL_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL" />
-    <option name="GO_METHOD_RECEIVER" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
-    <option name="GO_PACKAGE" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="GO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GO_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_METHOD_RECEIVER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="GO_PACKAGE_EXPORTED_CONSTANT">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
@@ -887,7 +927,11 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
-    <option name="GO_TYPE_REFERENCE" baseAttributes="DEFAULT_CLASS_REFERENCE" />
+    <option name="GO_TYPE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="GRID_ERROR_VALUE">
       <value>
         <option name="FOREGROUND" value="bf616a" />


### PR DESCRIPTION
Related to #69, #70
Fixes #108 

---

Like already documented and fixed in #70, IntelliJ/Goland version 2019.3 also [changes in Go's syntax highlight for the default bundled color schemes][goland].
This again requires to explicitly define the values for some attributes in order to achieve the same highlight like in previous versions that are matching Nord's style guidelines.

Unfortunately this resulted again in a change for existing theme definition where some editor color scheme keys that previously inherited the best matching global key now used the attributes defined by the parent theme _Darcula_. Therefore Nord's highlighting for Go broke again and required to explicitly define the values for some attributes in order to achieve the same highlight like in previous versions that are matching Nord's style guidelines.

<p align="center">Before</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62239717-b81fab80-b3d5-11e9-8e17-3b9d7fe3424e.png" /></p>

<p align="center">After</p>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/62239716-b81fab80-b3d5-11e9-9280-7829faea4370.png" /></p>

[goland]: https://www.jetbrains.com/go/whatsnew/#v2019-3-code-editing