### PR TITLE
Remove italic font style for RegEx braces and brackets

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1541,13 +1541,11 @@
     <option name="REGEXP.BRACES">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />
-        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.BRACKETS">
       <value>
-        <option name="FOREGROUND" value="e8bf6a" />
-        <option name="FONT_TYPE" value="2" />
+        <option name="FOREGROUND" value="ebcb8b" />
       </value>
     </option>
     <option name="REGEXP.CHAR_CLASS">


### PR DESCRIPTION
During the transition from the old to the new theme API the font style
for RegEx braces and brackets were changed to _italic_.
It looks way cleaner and less distracting without italic font style especially because it is mixed with normal styles.

<div align="center"><p><strong>Before</strong></p></div>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/70891834-58264c00-1fe8-11ea-8ff8-c55c2b3cb162.png"/></p>

<div align="center"><p><strong>After</strong></p></div>
<p align="center"><img src="https://user-images.githubusercontent.com/7836623/70891833-58264c00-1fe8-11ea-9f27-a7b90a411ff4.png"/></p>

---

Resolves #107