### PR TITLE
Fix wrong Type- and JavaScript highlighting inherited from parent scheme

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -3,7 +3,7 @@
     <property name="created">2016-09-24T21:08:20</property>
     <property name="ide">idea</property>
     <property name="ideVersion">2019.3.0.0</property>
-    <property name="modified">2019-12-02T09:34:36</property>
+    <property name="modified">2020-02-10T21:10:00</property>
     <property name="originalScheme">Nord</property>
   </metaInfo>
   <colors>
@@ -1099,9 +1099,43 @@
     </option>
     <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
     <option name="JAVA_VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
-    <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
-    <option name="JS.GLOBAL_VARIABLE" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
-    <option name="JS.INSTANCE_MEMBER_FUNCTION" baseAttributes="DEFAULT_INSTANCE_METHOD" />
+    <option name="JS.CLASS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="JS.EXPORTED.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="JS.EXPORTED.VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.GLOBAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="JS.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.INSTANCE_MEMBER_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+        <option name="JS.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="JS.REGEXP">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />


### PR DESCRIPTION
Fixes #115 

---

As of IDE versions 2019.3.x, some TypeScript and JavaScript syntax elements were not highlighted correctly. The following elements inherited the colors from the _Darcula_ parent scheme instead of the language defaults defined by Nord:

- _Global function_
- _Global variable_
- _Instance member function_
- _Instance member variable_

These elements are now using explicitly defined colors instead to fix the highlighting.

<div align="center">
	<p><strong>Before</strong></p>
	<img src="https://user-images.githubusercontent.com/7836623/74188692-3f848c00-4c4f-11ea-88af-de1b774d687b.png" />
	<p><strong>After</strong></p>
	<img src="https://user-images.githubusercontent.com/7836623/74188691-3eebf580-4c4f-11ea-9782-5cf27bbe41f9.png" />
</div>
