### PR TITLE
Remove unused `parent_scheme` attribute from root tag of editor scheme

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1,4 +1,4 @@
-<scheme name="Nord" version="142" parent_scheme="Darcula">
+<scheme name="Nord" version="142">
   <metaInfo>
     <property name="created">2016-09-24T21:08:20</property>
     <property name="ide">idea</property>


### PR DESCRIPTION
Related to #115, #116 

---

The `parent_scheme` is set automatically when a custom editor color scheme is created based on one of the bundled themes, like e.g. “Darcula“ when the IDE uses a dark theme or “Default“ in light mode.
Anyway, the attribute is not required at all and has been removed.

Moreover, to the time of this PR there's no real indicator in the [“IntelliJ IDEA Community Edition“ source code][1] that the attribute has any functionality but only [documenting the code base of the custom theme][2].

Nevertheless, it is possible that the attribute affects the logic how editor color schemes handle the inheritance of colors from other syntax definitions or the _Language Defaults_. There was an increasing amount of reported issues where syntax elements were highlighted with colors from the “Darcula“ editor scheme instead of the ones defined by Nord although the values must have been derived from other syntax definitions.
This might be caused by the `parent_scheme` attribute which was set to “Darcula.
Therefore the attribute has now been removed to mitigate such behavior.

Thanks to @Tom1206 for the idea of inspecting the attribute. See #115 for more details.

[1]: https://github.com/JetBrains/intellij-community/search?p=2&q=parent_scheme&unscoped_q=parent_scheme
[2]: https://github.com/JetBrains/intellij-community/blob/4491058316bab4162d2ee0a926ac65553b56e6a5/platform/editor-ui-ex/src/com/intellij/openapi/editor/colors/impl/AbstractColorsScheme.java#L311-L313