### PR TITLE
Fix invisible background color of inactive completion popup item

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -85,7 +85,7 @@
       "matchSelectionForeground": "#88c0d0",
       "nonFocusedState": "#2e3440",
       "selectionBackground": "#4c566a",
-      "selectionInactiveBackground": "#3b4252",
+      "selectionInactiveBackground": "#4c566a",
       "selectionInactiveInfoForeground": "#4c566a",
       "selectionInfoForeground": "#eceff4"
     },


### PR DESCRIPTION
Fixes #95
Related to #94

---

Before this PR, the background color of the marked entry in the completion popup when triggered while typing (enabled [“Show suggestions as you type“ option in preferences][1]) was the same like the background of the popup itself. As a result, the user did not know which entry was selected to complete the current line.
The problem only occurred when the completion popup was triggered while typing but not when being explicitly [invoked using the configured keymapping][2] (`Ctrl` / `⌃` + `Space` by default).
This was because the matching entry in the list, when invoked while typing, is _inactive_, but the color for inactive entries was the same like the background color of the popup itself.

This problem is now fixed by changing the color of the corresponding UI theme key `ui.CompletionPopup.selectionInactiveBackground` from `nord1` to `nord3`.

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74231745-9037cb80-4cc7-11ea-8695-cce2133da556.gif" />
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74231693-7302fd00-4cc7-11ea-84f9-17bb23175407.gif" />
</div>

[1]: https://www.jetbrains.com/help/idea/auto-completing-code.html#configure-code-completion
[2]: https://www.jetbrains.com/help/idea/auto-completing-code.html#invoke-basic-completion
