### PR TITLE
Replace all color inheritances with explicit definitions

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -108,6 +108,27 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="Abstract class name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="Annotation">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="Anonymous class name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="Anotation attribute name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="BAD_CHARACTER">
       <value>
         <option name="BACKGROUND" value="bf616a" />
@@ -117,6 +138,21 @@
     <option name="BASH.BACKQUOTE">
       <value>
         <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="BASH.BRACE">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="BASH.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="BASH.CONDITIONAL">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="BASH.EXTERNAL_COMMAND">
@@ -129,8 +165,18 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="BASH.FUNCTION_DEF_NAME">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="BASH.HERE_DOC">
       <value />
+    </option>
+    <option name="BASH.HERE_DOC_END">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
     </option>
     <option name="BASH.HERE_DOC_START">
       <value>
@@ -142,6 +188,31 @@
       <value>
         <option name="FOREGROUND" value="81a1c1" />
         <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="BASH.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="BASH.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="BASH.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="BASH.PAREN">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="BASH.RAW_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
     <option name="BASH.REDIRECTION">
@@ -156,10 +227,38 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="BASH.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="BASH.SUBSHELL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="BASH.VAR_DEF">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="BASH.VAR_USE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="BASH.VAR_USE_BUILTIN">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="EFFECT_COLOR" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="BASH.VAR_USE_COMPOSED">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -205,9 +304,45 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="BUILDOUT.KEY_VALUE_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="BUILDOUT.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
     <option name="BUILDOUT.SECTION_NAME">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="BUILDOUT.VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="Bad character">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Block comment">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="Braces">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="Brackets">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
       </value>
     </option>
     <option name="CABAL_KEYWORD">
@@ -215,9 +350,65 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BOOLEAN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BRACE">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="COFFEESCRIPT.CLASS_NAME">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.COLON">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.EXISTENTIAL">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.EXPRESSIONS_SUBSTITUTION_MARK">
@@ -225,7 +416,47 @@
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
-    <option name="COFFEESCRIPT.GLOBAL_VARIABLE" baseAttributes="" />
+    <option name="COFFEESCRIPT.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION_BINDING">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.FUNCTION_NAME">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREGEX_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.HEREGEX_ID">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="COFFEESCRIPT.JAVASCRIPT_CONTENT">
       <value>
         <option name="FOREGROUND" value="a3be8c" />
@@ -236,9 +467,54 @@
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
+    <option name="COFFEESCRIPT.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
     <option name="COFFEESCRIPT.OBJECT_KEY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.OPERATIONS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.PARENTHESIS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.PROTOTYPE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.RANGE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_CONTENT">
@@ -254,6 +530,26 @@
     <option name="COFFEESCRIPT.REGULAR_EXPRESSION_ID">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.SPLAT">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="COFFEESCRIPT.THIS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="CONSOLE_BLACK_OUTPUT">
@@ -375,9 +671,62 @@
         <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
+    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="CSS.ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="CSS.BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CSS.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="CSS.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="CSS.CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="CSS.COLON">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
     <option name="CSS.COLOR">
       <value>
         <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="CSS.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="CSS.COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="CSS.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
       </value>
     </option>
     <option name="CSS.FUNCTION">
@@ -385,12 +734,46 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="CSS.HASH">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="CSS.IDENT">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
     <option name="CSS.IMPORTANT">
       <value>
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
-    <option name="CSS.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="CSS.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="CSS.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="CSS.OPERATORS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="CSS.PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="CSS.PROPERTY_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="CSS.PROPERTY_VALUE">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
@@ -401,18 +784,43 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="CSS.TAG_NAME" baseAttributes="HTML_TAG_NAME" />
+    <option name="CSS.SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="CSS.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="CSS.TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
     <option name="CSS.UNICODE.RANGE">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />
       </value>
     </option>
-    <option name="CSS.URL" baseAttributes="HTML_ATTRIBUTE_VALUE" />
+    <option name="CSS.URL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="CTRL_CLICKABLE">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
         <option name="EFFECT_COLOR" value="88c0d0" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_INVALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
@@ -436,13 +844,41 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="CUSTOM_LINE_COMMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="CUSTOM_MULTI_LINE_COMMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="CUSTOM_NUMBER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
     <option name="CUSTOM_STRING_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
-    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
-    <option name="Class" baseAttributes="CLASS_NAME_ATTRIBUTES" />
+    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="Class">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="Closure braces">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="DART_CONSTRUCTOR">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -489,6 +925,17 @@
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
+    <option name="DEBUGGER_SMART_STEP_INTO_SELECTION">
+      <value>
+        <option name="EFFECT_COLOR" value="88c0d0" />
+      </value>
+    </option>
+    <option name="DEBUGGER_SMART_STEP_INTO_TARGET">
+      <value>
+        <option name="BACKGROUND" value="434c5e" />
+        <option name="EFFECT_COLOR" value="88c0d0" />
+      </value>
+    </option>
     <option name="DEFAULT_ATTRIBUTE">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -524,7 +971,11 @@
         <option name="FOREGROUND" value="eceff4" />
       </value>
     </option>
-    <option name="DEFAULT_CONSTANT" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="DEFAULT_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="DEFAULT_DOC_COMMENT">
       <value>
         <option name="FOREGROUND" value="616e88" />
@@ -652,6 +1103,16 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="DEFAULT_REASSIGNED_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="DEFAULT_REASSIGNED_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="DEFAULT_SEMICOLON">
       <value>
         <option name="FOREGROUND" value="eceff4" />
@@ -731,15 +1192,157 @@
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>
+    <option name="DJANGO_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="DJANGO_FILTER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="DJANGO_ID">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="DJANGO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="DJANGO_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="DJANGO_STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="DJANGO_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="DJANGO_TAG_START_END">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="DOCKER_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="DOCKER_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="DOCKER_COMMENTS">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="DOCKER_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="DOCKER_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="DOCKER_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="DOCKER_PARENTH">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="DOCKER_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="DOCKER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="4" />
+      </value>
+    </option>
     <option name="DUPLICATE_FROM_SERVER">
       <value>
         <option name="EFFECT_COLOR" value="ebcb8b" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
+    <option name="EL.BOUNDS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="EL.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="EL.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="EL.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="EL.IDENT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="EL.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="EL.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="EL.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="EL.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="EL_BACKGROUND">
       <value>
         <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="ENUM_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
     <option name="ERL_ATTRIBUTE">
@@ -776,6 +1379,11 @@
     <option name="EXECUTIONPOINT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="41536b" />
+      </value>
+    </option>
+    <option name="Enum name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
@@ -848,9 +1456,24 @@
         <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
+    <option name="GO_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_BRACKET">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="GO_BUILTIN_CONSTANT">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
     <option name="GO_BUILTIN_FUNCTION_CALL">
@@ -869,6 +1492,29 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_COLON">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="GO_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_COMMENT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="GO_EXPORTED_FUNCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -885,14 +1531,46 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_EXPORTED_STRUCT_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_FUNCTION_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="GO_KEYWORD">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
+    <option name="GO_LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
     <option name="GO_LINE_COMMENT">
       <value>
         <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
       </value>
     </option>
     <option name="GO_LOCAL_FUNCTION">
@@ -905,9 +1583,39 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="GO_LOCAL_INTERFACE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_STRUCT_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_VARIABLE_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="GO_METHOD_RECEIVER">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="GO_OPERATOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="GO_PACKAGE">
@@ -921,15 +1629,212 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_PACKAGE_EXPORTED_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="GO_PACKAGE_EXPORTED_VARIABLE">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_PACKAGE_EXPORTED_VARIABLE_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_VARIABLE_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_REASSIGNMENT_IN_SHORT_VAR_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_SCOPE_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_SHADOWING_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_COLOR" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="GO_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_EXPORTED_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_EXPORTED_MEMBER_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_LOCAL_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_LOCAL_MEMBER_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_BAD_TOKEN">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_DELIMITER">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_OPERATOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_PUNCTUATION">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="GO_TEMPLATE_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="GO_TYPE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_TYPE_SPECIFICATION">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="GO_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="GQL_ID">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="GQL_INT_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="GQL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GQL_STRING_LITERAL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
     <option name="GRID_ERROR_VALUE">
@@ -939,14 +1844,89 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
-    <option name="Groovy method declaration" baseAttributes="METHOD_DECLARATION_ATTRIBUTES" />
+    <option name="GRID_IMAGE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+        <option name="BACKGROUND" value="3b4252" />
+      </value>
+    </option>
+    <option name="GRID_NULL_VALUE">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="GROOVY_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GString">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="Groovy constructor call">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="4" />
+      </value>
+    </option>
+    <option name="Groovy constructor declaration">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="Groovy method declaration">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="Groovy parameter">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Groovy reassigned parameter">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Groovy reassigned var">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Groovy var">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Groovydoc comment">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="Groovydoc tag">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="HAML_CLASS">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
-    <option name="HAML_COMMENT" baseAttributes="" />
-    <option name="HAML_FILTER" baseAttributes="" />
+    <option name="HAML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="HAML_FILTER">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
     <option name="HAML_FILTER_CONTENT">
       <value>
         <option name="FONT_TYPE" value="2" />
@@ -960,15 +1940,41 @@
     <option name="HAML_LINE_CONTINUATION">
       <value />
     </option>
+    <option name="HAML_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="HAML_RUBY_CODE">
       <value>
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="HAML_RUBY_START" baseAttributes="" />
+    <option name="HAML_RUBY_START">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HAML_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="HAML_TAG">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="HAML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HAML_TEXT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
@@ -1035,11 +2041,109 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="HTML_ATTRIBUTE_NAME" baseAttributes="DEFAULT_ATTRIBUTE" />
-    <option name="HTML_ATTRIBUTE_VALUE" baseAttributes="DEFAULT_STRING" />
-    <option name="HTML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
-    <option name="HTML_TAG" baseAttributes="DEFAULT_TAG" />
-    <option name="HTML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="HTML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="HTML_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="HTML_CODE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="HTML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="HTML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="HTML_TAG">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="HTML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HTTP_HEADER_FIELD_NAME">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="HTTP_HEADER_FIELD_VALUE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_DIFFERENCE_FILE">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_DIFFERENCE_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_ENVIRONMENT_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_INPUT_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_MESSAGE_BODY">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_MULTIPART_BOUNDARY">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="4" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="HTTP_REQUEST_VARIABLE_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="HYPERLINK_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
@@ -1063,6 +2167,11 @@
         <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
+    <option name="INHERITED_METHOD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="INI.KEY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1079,6 +2188,22 @@
         <option name="BACKGROUND" value="3b4252" />
       </value>
     </option>
+    <option name="INSTANCE_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="INSTANCE_FINAL_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="INTERFACE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="Implicit conversion">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
@@ -1091,15 +2216,181 @@
     <option name="Implicit conversion second part">
       <value />
     </option>
+    <option name="Instance field">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Instance property reference ID">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Interface name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="Interpolated String Injection">
       <value>
         <option name="FOREGROUND" value="a3be8c" />
         <option name="FONT_TYPE" value="2" />
       </value>
     </option>
-    <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="JAVA_VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
+    <option name="Invalid string escape">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JAVA_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JAVA_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JAVA_DOC_TAG">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JAVA_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JAVA_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JAVA_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JAVA_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="JAVA_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JAVA_PARENTH">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JAVA_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="JAVA_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="JS.BADCHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JS.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JS.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="JS.CLASS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="JS.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JS.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="JS.DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JS.DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JS.DOC_TAG">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JS.EXPORTED.CLASS">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
@@ -1113,6 +2404,11 @@
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.FUNCTION_ARROW">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="JS.GLOBAL_FUNCTION">
@@ -1131,9 +2427,77 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-        <option name="JS.LOCAL_VARIABLE">
+    <option name="JS.INSTANCE_MEMBER_VARIABLE">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="JS.INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JS.LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="JS.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JS.LOCAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="JS.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="JS.MODULE_NAME">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="JS.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="JS.OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JS.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="JS.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JS.PRIMITIVE.TYPE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="JS.REGEXP">
@@ -1141,15 +2505,124 @@
         <option name="FOREGROUND" value="ebcb8b" />
       </value>
     </option>
+    <option name="JS.SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JS.STATIC_MEMBER_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.STATIC_MEMBER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JS.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="JS.TYPE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="JS.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="JSON.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JSON.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JSON.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JSON.COLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JSON.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="JSON.INVALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="JSON.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="JSON.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="JSON.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
     <option name="JSON.PROPERTY_KEY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="JSON.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="JSON.VALID_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="JSP_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="JSP_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="JSP_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
     <option name="JSP_DIRECTIVE_BACKGROUND">
       <value />
     </option>
-    <option name="JSP_DIRECTIVE_NAME" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="JSP_DIRECTIVE_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
     <option name="JSP_SCRIPTING_BACKGROUND">
       <value>
         <option name="FOREGROUND" value="5e81ac" />
@@ -1157,7 +2630,7 @@
     </option>
     <option name="JUPYTER_CELL_MARKER">
       <value>
-        <option name="FOREGROUND" value="616e88" />
+        <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
     <option name="JUPYTER_INLINE_VALUES">
@@ -1171,18 +2644,107 @@
         <option name="EFFECT_COLOR" value="d8dee9" />
       </value>
     </option>
-    <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES" />
+    <option name="KDOC_LINK">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="4" />
+      </value>
+    </option>
+    <option name="KDOC_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="KOTLIN_ABSTRACT_CLASS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="KOTLIN_ANNOTATION">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="KOTLIN_ARROW">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="KOTLIN_BACKING_FIELD_VARIABLE">
       <value />
+    </option>
+    <option name="KOTLIN_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="KOTLIN_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="KOTLIN_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="KOTLIN_BUILTIN_ANNOTATION">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="KOTLIN_CLASS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
     </option>
     <option name="KOTLIN_CLOSURE_DEFAULT_PARAMETER">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
       </value>
     </option>
+    <option name="KOTLIN_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="KOTLIN_CONSTRUCTOR">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="KOTLIN_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="KOTLIN_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="KOTLIN_DSL_STYLE1">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="KOTLIN_DSL_STYLE2">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="KOTLIN_DSL_STYLE3">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="KOTLIN_DSL_STYLE4">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+        <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
     <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
@@ -1197,12 +2759,59 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="KOTLIN_EXTENSION_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="KOTLIN_EXTENSION_PROPERTY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="KOTLIN_LABEL" baseAttributes="DEFAULT_LABEL" />
+    <option name="KOTLIN_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="KOTLIN_FUNCTION_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="KOTLIN_INSTANCE_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="KOTLIN_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="KOTLIN_LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="KOTLIN_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="KOTLIN_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="KOTLIN_MUTABLE_VARIABLE">
       <value>
         <option name="EFFECT_COLOR" value="d8dee9" />
@@ -1214,9 +2823,51 @@
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="KOTLIN_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="KOTLIN_OBJECT">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="KOTLIN_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="KOTLIN_PACKAGE_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_PACKAGE_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="KOTLIN_PARENTHESIS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="KOTLIN_SAFE_ACCESS">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="KOTLIN_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
       </value>
     </option>
     <option name="KOTLIN_SMART_CAST_RECEIVER">
@@ -1239,7 +2890,37 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="KOTLIN_TYPE_PARAMETER" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES" />
+    <option name="KOTLIN_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="KOTLIN_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="KOTLIN_SYNTHETIC_EXTENSION_PROPERTY">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="KOTLIN_TRAIT">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="KOTLIN_TYPE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="KOTLIN_TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="KOTLIN_VARIABLE_AS_FUNCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1254,12 +2935,166 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
+    <option name="KOTLIN_WRAPPED_INTO_REF">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="LAMBDA_PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="LESS_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="LESS_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_COLON">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="LESS_COLOR">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="LESS_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="LESS_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="LESS_IDENT">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_ID_SELECTOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_IMPORTANT">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="LESS_INJECTED_CODE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
     <option name="LESS_JS_CODE_DELIM">
       <value>
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
-    <option name="LESS_VARIABLE" baseAttributes="" />
+    <option name="LESS_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="LESS_OPERATORS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_PROPERTY_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="LESS_PROPERTY_VALUE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_PSEUDO">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="LESS_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="LESS_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="LESS_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="LESS_UNICODE_RANGE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="LESS_URL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="LESS_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="LINE_FULL_COVERAGE">
       <value>
         <option name="FOREGROUND" value="a3be8c" />
@@ -1281,6 +3116,11 @@
     <option name="LIVE_TEMPLATE_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="88c0d0" />
+      </value>
+    </option>
+    <option name="LOCAL_VARIABLE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
       </value>
     </option>
     <option name="LOGCAT_INFO_OUTPUT">
@@ -1353,16 +3193,84 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="Label">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="Lambda braces">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="Line comment">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
     <option name="List/map to object conversion">
       <value>
         <option name="FOREGROUND" value="eceff4" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="MAKO.SUBSTITUTION" baseAttributes="DEFAULT_TEMPLATE_LANGUAGE_COLOR" />
+    <option name="MAKO.ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="MAKO.ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="MAKO.CONTROL_STRUCTURE_ID">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="MAKO.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="MAKO.SUBSTITUTION">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="MAKO.TAG">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="MAKO.TAG_ID">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_AUTO_LINK">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_COLOR" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="MARKDOWN_BLOCK_QUOTE">
       <value>
         <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="MARKDOWN_BLOCK_QUOTE_MARKER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_BOLD_MARKER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="MARKDOWN_CODE_BLOCK">
@@ -1383,6 +3291,11 @@
     <option name="MARKDOWN_CODE_SPAN_MARKER">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_EXPLICIT_LINK">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
     <option name="MARKDOWN_HEADER_LEVEL_1">
@@ -1428,10 +3341,27 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
+    <option name="MARKDOWN_HTML_BLOCK">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="MARKDOWN_IMAGE">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
     <option name="MARKDOWN_INLINE_HTML">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
         <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="MARKDOWN_ITALIC_MARKER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
     <option name="MARKDOWN_LINK_DESTINATION">
@@ -1457,9 +3387,35 @@
         <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
+    <option name="MARKDOWN_LIST_ITEM">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="MARKDOWN_LIST_MARKER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="MARKDOWN_STRIKE_THROUGH">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+        <option name="EFFECT_COLOR" value="ebcb8b" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
     <option name="MARKDOWN_TABLE_SEPARATOR">
       <value>
         <option name="FOREGROUND" value="4c566a" />
+      </value>
+    </option>
+    <option name="MARKDOWN_TEXT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
     <option name="MARKED_FOR_REMOVAL_ATTRIBUTES">
@@ -1474,6 +3430,26 @@
         <option name="EFFECT_COLOR" value="88c0d0" />
       </value>
     </option>
+    <option name="METHOD_CALL_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="METHOD_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="Map key">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="Method call">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="NOT_TOP_FRAME_ATTRIBUTES">
       <value />
     </option>
@@ -1481,6 +3457,11 @@
       <value>
         <option name="EFFECT_COLOR" value="ebcb8b" />
         <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="Number">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
       </value>
     </option>
     <option name="OGNL.BACKGROUND">
@@ -1491,14 +3472,78 @@
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
-    <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE" />
+    <option name="Operation sign">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="PROPERTIES.KEY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="DEFAULT_OPERATION_SIGN" />
-    <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
+    <option name="PROPERTIES.KEY_VALUE_SEPARATOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PROPERTIES.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PROPERTIES.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="PROPERTIES.VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="PROTO_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PROTO_ENUM_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PROTO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PROTO_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PROTO_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="PROTO_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="PUPPET_HEREDOC_BODY">
       <value>
         <option name="FOREGROUND" value="4c566a" />
@@ -1526,15 +3571,50 @@
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="PY.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PY.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="PY.BUILTIN_NAME">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="PY.CLASS_DEFINITION" baseAttributes="DEFAULT_CLASS_NAME" />
+    <option name="PY.CLASS_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="PY.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="PY.DECORATOR">
       <value>
         <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="PY.DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PY.DOC_COMMENT_TAG">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
       </value>
     </option>
     <option name="PY.FSTRING_FRAGMENT_BRACES">
@@ -1547,8 +3627,68 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER" />
+    <option name="PY.FSTRING_FRAGMENT_TYPE_CONVERSION">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="PY.FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PY.FUNC_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PY.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PY.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PY.METHOD_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PY.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="PY.OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PY.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PY.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="PY.PREDEFINED_DEFINITION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1566,10 +3706,111 @@
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING" />
+    <option name="PY.STRING.B">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="PY.STRING.U">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="PY.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="Parentheses">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="QL_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="QL_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="QL_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="QL_DATETIME">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="QL_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="QL_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="QL_FUNCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="QL_ID_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="QL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="QL_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="QL_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="QL_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="QL_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="QL_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="REASSIGNED_PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="REGEXP.BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="REGEXP.BRACES">
@@ -1582,16 +3823,66 @@
         <option name="FOREGROUND" value="ebcb8b" />
       </value>
     </option>
+    <option name="REGEXP.CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="REGEXP.CHAR_CLASS">
       <value>
         <option name="FOREGROUND" value="d08770" />
       </value>
     </option>
-    <option name="REGEXP.ESC_CHARACTER" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
-    <option name="REGEXP.META" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="REGEXP.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="REGEXP.COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="REGEXP.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="REGEXP.ESC_CHARACTER">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="REGEXP.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="REGEXP.META">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="REGEXP.NAME">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="REGEXP.OPTIONS">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
     <option name="REGEXP.PARENTHS">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="REGEXP.QUANTIFIER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
       </value>
     </option>
     <option name="REGEXP.QUOTE_CHARACTER">
@@ -1633,11 +3924,93 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="SASS_COMMENT" baseAttributes="" />
+    <option name="SASS_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SASS_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SASS_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SASS_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_COLON">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="SASS_COLOR">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="SASS_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SASS_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="SASS_DEFAULT">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SASS_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="SASS_EXTEND">
       <value>
         <option name="FOREGROUND" value="d08770" />
         <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="SASS_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="SASS_GLOBAL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SASS_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_ID_SELECTOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_IMPORTANT">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
     <option name="SASS_INTERPOLATION">
@@ -1646,12 +4019,81 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
+    <option name="SASS_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
     <option name="SASS_MIXIN">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="SASS_VARIABLE" baseAttributes="" />
+    <option name="SASS_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="SASS_OPERATORS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_OPTIONAL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SASS_PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SASS_PROPERTY_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SASS_PROPERTY_VALUE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_PSEUDO">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="SASS_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SASS_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="SASS_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SASS_UNICODE_RANGE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="SASS_URL">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="SASS_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="434c5e" />
@@ -1661,14 +4103,100 @@
     <option name="SPEL.BACKGROUND">
       <value />
     </option>
+    <option name="SPEL.BEAN_PREFIX">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
     <option name="SPEL.BOUNDS">
       <value>
         <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
+    <option name="SPEL.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.COLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="SPEL.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SPEL.METHOD_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="SPEL.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="SPEL.OPERATIONS">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SPEL.PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SPEL.PROPERTY_KEY">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="SPEL.QUALIFIED_TYPE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SPEL.STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SPEL.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="SPY-JS.EXCEPTION">
       <value>
         <option name="EFFECT_COLOR" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="SPY-JS.EXECUTION_TIME">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="SPY-JS.FUNCTION_SCOPE">
@@ -1692,12 +4220,163 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
+    <option name="SQL_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SQL_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_COLUMN">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="SQL_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="SQL_DATABASE_OBJECT">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SQL_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_EXTERNAL_TOOL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SQL_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SQL_LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SQL_LOCAL_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="SQL_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="SQL_OUTER_QUERY_COLUMN">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="SQL_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SQL_PARENS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_PROCEDURE">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SQL_SCHEMA">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SQL_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="SQL_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="SQL_SYNTHETIC_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="SQL_TABLE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="SQL_TYPE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SQL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="STATIC_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="STATIC_FIELD_IMPORTED_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
       </value>
     </option>
-    <option name="STATIC_METHOD_ATTRIBUTES" baseAttributes="DEFAULT_STATIC_METHOD" />
+    <option name="STATIC_FINAL_FIELD_IMPORTED_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="STATIC_METHOD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="STATIC_METHOD_IMPORTED_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="STYLUS_FUNCTION_NAME">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1762,8 +4441,32 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES" />
-    <option name="Static property reference ID" baseAttributes="STATIC_FINAL_FIELD_ATTRIBUTES" />
+    <option name="Static field">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="Static method access">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Static property reference ID">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="String">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="TAG_ATTR_KEY">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="TAPESTRY_COMPONENT_PARAMATER">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -1783,6 +4486,13 @@
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="BACKGROUND" value="3b4252" />
+      </value>
+    </option>
+    <option name="TDIFF_FUZZY_MISMATCHED">
+      <value>
+        <option name="BACKGROUND" value="434c5e" />
+        <option name="EFFECT_COLOR" value="88c0d0" />
+        <option name="ERROR_STRIPE_COLOR" value="88c0d0" />
       </value>
     </option>
     <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
@@ -1812,12 +4522,175 @@
         <option name="ERROR_STRIPE_COLOR" value="88c0d0" />
       </value>
     </option>
-    <option name="TS.INTERFACE">
+    <option name="TS.BADCHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TS.BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="TS.BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.CLASS">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="TS.COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="TS.DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="TS.DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TS.DOC_TAG">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="TS.DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.FUNCTION_ARROW">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TS.GLOBAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="TS.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="TS.INSTANCE_MEMBER_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="TS.INSTANCE_MEMBER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="TS.INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="TS.INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TS.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TS.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="TS.LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="TS.MODULE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="TS.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="TS.OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TS.PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="TS.PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.PRIMITIVE.TYPES">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TS.REGEXP">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="TS.SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="TS.STATIC_MEMBER_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TS.STATIC_MEMBER_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TS.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="TS.TYPE.ALIAS">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
@@ -1832,6 +4705,11 @@
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="TS.VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -1841,6 +4719,17 @@
       <value>
         <option name="EFFECT_COLOR" value="a3be8c" />
         <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="Trait name">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="Type parameter">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
     <option name="UNMATCHED_BRACE_ATTRIBUTES">
@@ -1855,12 +4744,68 @@
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
+    <option name="VELOCITY_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="VELOCITY_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="VELOCITY_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="VELOCITY_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="VELOCITY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
     <option name="VELOCITY_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="VELOCITY_DOT">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="VELOCITY_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="VELOCITY_KEYWORD">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
       </value>
     </option>
-    <option name="VELOCITY_KEYWORD" baseAttributes="" />
+    <option name="VELOCITY_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="VELOCITY_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="VELOCITY_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="VELOCITY_REFERENCE">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -1868,6 +4813,21 @@
     </option>
     <option name="VELOCITY_SCRIPTING_BACKGROUND">
       <value />
+    </option>
+    <option name="VELOCITY_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="VELOCITY_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="Valid string escape">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
@@ -1896,8 +4856,26 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="XML_ATTRIBUTE_NAME" baseAttributes="DEFAULT_ATTRIBUTE" />
-    <option name="XML_ENTITY_REFERENCE" baseAttributes="DEFAULT_ENTITY" />
+    <option name="XML_ATTRIBUTE_NAME">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="XML_ATTRIBUTE_VALUE">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="XML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="XML_ENTITY_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
     <option name="XML_NS_PREFIX">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1917,19 +4895,114 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="XML_TAG_DATA" baseAttributes="TEXT" />
-    <option name="XML_TAG_NAME" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="XPATH.KEYWORD" baseAttributes="" />
+    <option name="XML_TAG_DATA">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="XML_TAG_NAME">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="XPATH.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="XPATH.FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="XPATH.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="XPATH.NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="XPATH.OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="XPATH.PARENTH">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="XPATH.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="XPATH.XPATH_NAME">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="XPATH.XPATH_VARIABLE" baseAttributes="" />
+    <option name="XPATH.XPATH_PREFIX">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="XPATH.XPATH_TEXT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="XPATH.XPATH_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="XSLT_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="YAML_ANCHOR">
+      <value>
+        <option name="FOREGROUND" value="d08770" />
+      </value>
+    </option>
+    <option name="YAML_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_DSTRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="YAML_SCALAR_KEY">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_LIST">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="YAML_SCALAR_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
     <option name="YAML_SCALAR_VALUE">
@@ -1938,13 +5011,59 @@
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
-    <option name="com.plan9.IDENTIFIER" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="YAML_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="YAML_TEXT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="BACKGROUND" value="2e3440" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="com.plan9.FLAG">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="com.plan9.IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
     <option name="com.plan9.INSTRUCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
-    <option name="com.plan9.LABEL" baseAttributes="DEFAULT_LABEL" />
+    <option name="com.plan9.KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="com.plan9.LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="com.plan9.LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="com.plan9.OPERATOR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="com.plan9.PARENTHESIS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
     <option name="com.plan9.PSEUDO_INSTRUCTION">
       <value>
         <option name="FOREGROUND" value="88c0d0" />
@@ -1955,6 +5074,11 @@
     <option name="com.plan9.REGISTER">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="com.plan9.STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
   </attributes>


### PR DESCRIPTION
Related to #69, #70, #77, #78, #108, #109, #115, #117, #119, #120

---

This PR implements the workaround documented in #120 to prevent more "random" color style breakages. It replaces all editor color scheme keys that inherit values from other keys with the explicit style definitions instead.
This causes the code of the editor scheme to increase drastically due to duplicate and repeated styles, but it currently the only way to work around this non-working style inheritance in the IDE theme API.