### PR TITLE
Support new editor scheme key for runtime errors

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -3924,6 +3924,13 @@
         <option name="FOREGROUND" value="88c0d0" />
       </value>
     </option>
+    <option name="RUNTIME_ERROR">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+        <option name="EFFECT_COLOR" value="bf616a" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
     <option name="SASS_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="81a1c1" />


### PR DESCRIPTION
Closes #127

---

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74591004-42e39300-5014-11ea-8d1a-75f92279ae29.png" />
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74591003-424afc80-5014-11ea-819b-440314c66675.png" />
</div>
