### PR TITLE
Support background color styling of "diff" UI separator

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -22,6 +22,7 @@
     <option name="DIAGRAM_NOTE_BACKGROUND" value="434c5e" />
     <option name="DIAGRAM_NOTE_BORDER" value="434c5e" />
     <option name="DIAGRAM_REALIZATION_EDGE" value="a3be8c" />
+    <option name="DIFF_SEPARATORS_BACKGROUND" value="4c566a" />
     <option name="DOCUMENTATION_COLOR" value="3b4252" />
     <option name="ERROR_HINT" value="434c5e" />
     <option name="FILESTATUS_ADDED" value="a3be8c" />


### PR DESCRIPTION
Closes #128 
Thanks to @Tom1206 for the report in https://github.com/arcticicestudio/nord-jetbrains/issues/120#issuecomment-585635441

---

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74591083-1da35480-5015-11ea-95ef-e8e4449baca9.png" />
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74591082-1d0abe00-5015-11ea-8d32-d9f886faec21.png" />
</div>
