### PR TITLE
Support highlighting of separator lines between editor and breadcrumbs

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -57,6 +57,8 @@
     <option name="RIGHT_MARGIN_COLOR" value="4c566a" />
     <option name="SELECTED_TEARLINE_COLOR" value="434c5e" />
     <option name="SELECTION_BACKGROUND" value="434c5e" />
+    <option name="SEPARATOR_ABOVE_COLOR" value="4c566a" />
+    <option name="SEPARATOR_BELOW_COLOR" value="f000d7" />
     <option name="SOFT_WRAP_SIGN_COLOR" value="4c566a" />
     <option name="TEARLINE_COLOR" value="4c566a" />
     <option name="VCS_ANNOTATIONS_COLOR_1" value="3b4252" />


### PR DESCRIPTION
Closes #125 

---

<div align="center">
  <img src="https://user-images.githubusercontent.com/7836623/74591406-02861400-5018-11ea-9759-d92f3f345073.png" />
</div>
