### PR TITLE
Fix editor & breadcrumbs separator line color

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -61,7 +61,7 @@
     <option name="SELECTED_TEARLINE_COLOR" value="434c5e" />
     <option name="SELECTION_BACKGROUND" value="434c5e" />
     <option name="SEPARATOR_ABOVE_COLOR" value="4c566a" />
-    <option name="SEPARATOR_BELOW_COLOR" value="f000d7" />
+    <option name="SEPARATOR_BELOW_COLOR" value="4c566a" />
     <option name="SOFT_WRAP_SIGN_COLOR" value="4c566a" />
     <option name="TAB_UNDERLINE" value="88c0d0" />
     <option name="TAB_UNDERLINE_INACTIVE" value="616e88" />


### PR DESCRIPTION
Fixes #138 

---
<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74600789-a0b8bf00-5096-11ea-9434-7a1f72887674.png" />
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74600787-a0202880-5096-11ea-832d-23206bd3168c.png" />
</div>
