### PR TITLE
Fix highlighting of "injected language fragments"

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -2186,9 +2186,7 @@
       </value>
     </option>
     <option name="INJECTED_LANGUAGE_FRAGMENT">
-      <value>
-        <option name="FOREGROUND" value="5e81ac" />
-      </value>
+      <value />
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>


### PR DESCRIPTION
Fixes #140 

---

<div align="center">
  <p><strong>Before</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74656142-ddb3ad00-518d-11ea-9fa7-48751885d3b2.png" />
  <p><strong>After</strong></p>
  <img src="https://user-images.githubusercontent.com/7836623/74656139-dd1b1680-518d-11ea-850d-195d671dd51d.png" />
</div>