### PR TITLE
Add some color to Clojure keywords to help distinguish them

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -882,6 +882,11 @@
         <option name="FOREGROUND" value="8fbcbb" />
       </value>
     </option>
+    <option name="Clojure Keyword">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
     <option name="Closure braces">
       <value>
         <option name="FOREGROUND" value="eceff4" />


### PR DESCRIPTION
Keywords in clojure (like atoms in Erlang/Elixir or symbols in Ruby, e.x. `:name`) are constants and often used as keys in maps.

It's helpful to differentiate them from identifiers, so this patch colors them with the same color used for HTML attribute names.

Everything else looked good out of the box.

![clojure-nord](https://user-images.githubusercontent.com/4692/77169159-6bd1ca80-6a8f-11ea-94cb-2e5bfd416b31.png)

Nord rocks, I discovered this scheme yesterday and have nord-ified mulitple machines :)