### PR TITLE
Add explicit support for bundled PhpStorm language syntax

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -3,7 +3,7 @@
     <property name="created">2016-09-24T21:08:20</property>
     <property name="ide">idea</property>
     <property name="ideVersion">2019.3.0.0</property>
-    <property name="modified">2020-02-16T08:34:12</property>
+    <property name="modified">2020-04-27T14:48:34</property>
     <property name="originalScheme">Nord</property>
   </metaInfo>
   <colors>
@@ -49,8 +49,8 @@
     <option name="HTML_TAG_TREE_LEVEL5" value="" />
     <option name="INDENT_GUIDE" value="4c566a" />
     <option name="INFORMATION_HINT" value="434c5e" />
-    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="d8dee9" />
     <option name="LINE_NUMBERS_COLOR" value="4c566a" />
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="d8dee9" />
     <option name="METHOD_SEPARATORS_COLOR" value="d8dee9" />
     <option name="MODIFIED_LINES_COLOR" value="ebcb8b" />
     <option name="NOTIFICATION_BACKGROUND" value="4c566a" />
@@ -268,6 +268,27 @@
       <value>
         <option name="FOREGROUND" value="d8dee9" />
         <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="BLADE_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="BLADE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="BLADE_DIRECTIVE">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="BLADE_TEXT_BLOCK_BOUNDARY">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
     <option name="BOOKMARKS_ATTRIBUTES">
@@ -1451,6 +1472,11 @@
     <option name="GHERKIN_TABLE_PIPE">
       <value>
         <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="GOTO_LABEL">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
       </value>
     </option>
     <option name="GO_BAD_TOKEN">
@@ -3220,6 +3246,13 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="MAGIC_MEMBER_ACCESS">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="EFFECT_COLOR" value="d8dee9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="MAKO.ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="8fbcbb" />
@@ -3486,6 +3519,229 @@
     <option name="PARAMETER_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_ALIAS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PHP_BRACES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PHP_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PHP_CLASS">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="PHP_COMMA">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PHP_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PHP_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PHP_DOC_COMMENT_ID">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="PHP_DOC_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+      </value>
+    </option>
+    <option name="PHP_DOC_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_DOC_TAG">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PHP_DOC_VAR">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_ESCAPE_SEQUENCE">
+      <value>
+        <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="PHP_EXEC_COMMAND_ID">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+        <option name="EFFECT_TYPE" value="4" />
+      </value>
+    </option>
+    <option name="PHP_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="PHP_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="PHP_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_INSTANCE_METHOD">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="8fbcbb" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PHP_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_MARKUP_ID">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="PHP_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_PARENTHESES">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PHP_PREDEFINED SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_PRIMITIVE_TYPE_HINT">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_PRIVATE_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_PRIVATE_INSTANCE_METHOD">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_PROTECTED_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_PROTECTED_INSTANCE_METHOD">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+      </value>
+    </option>
+    <option name="PHP_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="eceff4" />
+      </value>
+    </option>
+    <option name="PHP_STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PHP_STATIC_METHOD">
+      <value>
+        <option name="FOREGROUND" value="88c0d0" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="PHP_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
+    <option name="PHP_TAG">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_THIS_VAR">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="PHP_VAR">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="PHP_VAR_VAR">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+        <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="PROPERTIES.INVALID_STRING_ESCAPE">
@@ -4113,6 +4369,47 @@
         <option name="EFFECT_COLOR" value="88c0d0" />
       </value>
     </option>
+    <option name="SMARTY_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="SMARTY_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="SMARTY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="SMARTY_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="SMARTY_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SMARTY_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="SMARTY_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="SMARTY_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
+      </value>
+    </option>
     <option name="SPEL.BACKGROUND">
       <value />
     </option>
@@ -4733,6 +5030,47 @@
     <option name="TS.VALID_STRING_ESCAPE">
       <value>
         <option name="FOREGROUND" value="ebcb8b" />
+      </value>
+    </option>
+    <option name="TWIG_BAD_CHARACTER">
+      <value>
+        <option name="BACKGROUND" value="bf616a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TWIG_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="5e81ac" />
+      </value>
+    </option>
+    <option name="TWIG_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="616e88" />
+      </value>
+    </option>
+    <option name="TWIG_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="d8dee9" />
+      </value>
+    </option>
+    <option name="TWIG_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TWIG_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="b48ead" />
+      </value>
+    </option>
+    <option name="TWIG_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="81a1c1" />
+      </value>
+    </option>
+    <option name="TWIG_STRING">
+      <value>
+        <option name="FOREGROUND" value="a3be8c" />
       </value>
     </option>
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">


### PR DESCRIPTION
Related to #120, #121
Closes #151

---

[PhpStorm][] ships with support for specific languages, frameworks and libraries for PHP development and of course advanced highlighting for [PHP][] itself. Due to the same problems like documented in #120 (mitigated in #121) some syntax theme keys required to be replaced with explicit definitions instead of relying on color inheritances.

Therefore this PR adds explicit support for PhpStorm's bundled language syntax:

1. Main support for [PHP][] and the [official JetBrains plugin][jb-plug-php]
2. [Laravel "Blade" Templates][blade]
   See [JetBrains official “Blade“ documentation][jb-docs-blade] and [the plugin][jb-plug-blade] for more details.
3. "Twig" template engine
   See [JetBrains official “Twig“ documentation][jb-docs-twig] and [the plugin][jb-plug-twig] for more details.
4. "Smarty" templates
   See [JetBrains official “Smarty“ documentation][jb-docs-smarty] for more details.

<p align="center">PHP syntax highlighting <strong>before</strong> and <strong>after</strong></p>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377431-920f3500-889b-11ea-9604-4c1f4fb16919.png" /></div>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377419-8e7bae00-889b-11ea-8c84-a8b569242920.png" /></div>

<p align="center">Blade syntax highlighting <strong>before</strong> and <strong>after</strong></p>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377487-a3f0d800-889b-11ea-8082-7f3403a1d3b1.png" /></div>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377486-a3584180-889b-11ea-8ad7-a99f73468552.png" /></div>

<p align="center">Twig syntax highlighting <strong>before</strong> and <strong>after</strong></p>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377495-a5ba9b80-889b-11ea-9f8c-714782d3c093.png" /></div>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377492-a5220500-889b-11ea-8d6d-522399c83351.png" /></div>

<p align="center">Smarty syntax highlighting <strong>before</strong> and <strong>after</strong></p>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377491-a4896e80-889b-11ea-942e-e5ed47b402a8.png" /></div>
<div align="center"><img src="https://user-images.githubusercontent.com/7836623/80377490-a4896e80-889b-11ea-8c52-fff7ebe40567.png" /></div>

[blade]: https://laravel.com/docs/7.x/blade
[jb-docs-blade]: https://www.jetbrains.com/help/phpstorm/blade-page.html
[jb-docs-smarty]: https://www.jetbrains.com/help/phpstorm/smarty.html
[jb-docs-twig]: https://www.jetbrains.com/help/phpstorm/symfony-twig.html
[jb-plug-blade]: https://plugins.jetbrains.com/plugin/7569-blade
[jb-plug-php]: https://plugins.jetbrains.com/plugin/6610-php
[jb-plug-twig]: https://plugins.jetbrains.com/plugin/7303-twig
[php]: https://www.php.net
[phpstorm]: https://www.jetbrains.com/phpstorm
[smarty]: https://www.smarty.net
[twig]: https://twig.symfony.com