### PR TITLE
fix: selection is barely recognized in the same line

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -26,7 +26,7 @@
       "lightSelectionInactiveForeground": "#d8dee9",
       "lineSeparatorColor": "#4c566a",
       "modifiedItemForeground": "#ebcb8b",
-      "selectionBackground": "#4c566a",
+      "selectionBackground": "#4b6173",
       "selectionBackgroundInactive": "#434c5e",
       "selectionForeground": "#eceff4",
       "selectionInactiveBackground": "#434c5e",


### PR DESCRIPTION
In order to fix #156

This is with the fix:

<img width="262" alt="Screen Shot 2020-05-14 at 4 41 58 PM" src="https://user-images.githubusercontent.com/23299193/81988911-dcb1e080-9601-11ea-8e78-6c33b590b206.png">
