### PR TITLE
Reduce alpha value of patch background colors

### DIFF
--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1210,14 +1210,14 @@
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="3e4a59" />
+        <option name="BACKGROUND" value="3f4a5a" />
         <option name="ERROR_STRIPE_COLOR" value="81a1c1" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="53524e" />
+        <option name="BACKGROUND" value="54524f" />
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>

--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1203,21 +1203,21 @@
     <option name="DIFF_DELETED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="68465180" />
+        <option name="BACKGROUND" value="5a3943" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="5d6b5e50" />
+        <option name="BACKGROUND" value="3e4b3e" />
         <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="7a705e50" />
+        <option name="BACKGROUND" value="4b4b3c" />
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>

--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1196,22 +1196,22 @@
     <option name="DIFF_CONFLICT">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="3d4c61" />
+        <option name="BACKGROUND" value="374355" />
         <option name="ERROR_STRIPE_COLOR" value="5e81ac" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="5b424d" />
+        <option name="BACKGROUND" value="4b3d48" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="454f4e" />
-        <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
+        <option name="BACKGROUND" value="3e4a59" />
+        <option name="ERROR_STRIPE_COLOR" value="81a1c1" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">

--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1196,28 +1196,28 @@
     <option name="DIFF_CONFLICT">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="41536b" />
+        <option name="BACKGROUND" value="3d4c61" />
         <option name="ERROR_STRIPE_COLOR" value="5e81ac" />
       </value>
     </option>
     <option name="DIFF_DELETED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="5a3943" />
+        <option name="BACKGROUND" value="5b424d" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="3e4b3e" />
+        <option name="BACKGROUND" value="454f4e" />
         <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="4b4b3c" />
+        <option name="BACKGROUND" value="53524e" />
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>

--- a/resources/themes/nord.xml
+++ b/resources/themes/nord.xml
@@ -1203,21 +1203,21 @@
     <option name="DIFF_DELETED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="684651" />
+        <option name="BACKGROUND" value="68465180" />
         <option name="ERROR_STRIPE_COLOR" value="bf616a" />
       </value>
     </option>
     <option name="DIFF_INSERTED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="5d6b5e" />
+        <option name="BACKGROUND" value="5d6b5e50" />
         <option name="ERROR_STRIPE_COLOR" value="a3be8c" />
       </value>
     </option>
     <option name="DIFF_MODIFIED">
       <value>
         <option name="FOREGROUND" value="2e3440" />
-        <option name="BACKGROUND" value="7a705e" />
+        <option name="BACKGROUND" value="7a705e50" />
         <option name="ERROR_STRIPE_COLOR" value="ebcb8b" />
       </value>
     </option>


### PR DESCRIPTION
Adjust the alpha of the background for diff inserted and modified blocks down to 50 to improve contrast with foreground (especially comments), and adjust diff deleted down to 80 as a minor improvement of the same.

Addresses issue: https://github.com/arcticicestudio/nord-jetbrains/issues/103