### PR TITLE
Override background for JVM memory indicator

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -164,6 +164,10 @@
       "background": "#323846",
       "selectionInactiveForeground": "#e5e9f0"
     },
+    "MemoryIndicator": {
+      "allocatedBackground": "#81a1c1",
+      "usedBackground": "#5e81ac"
+    },
     "Menu": {
       "background": "#323846",
       "borderColor": "#3b4252",


### PR DESCRIPTION
Add an explicit color overrides for JVM memory indicator (seems like "standard grey" from Darcula is used by default).

Initially I've tried to use `5e81ac` + `88c0d0` color combo, but it resulted in a badly readable memory numbers, so I decided to switch  `88c0d0` to a more "darker" `81a1c1`. Open to other color suggestions :)

Before:
![image](https://user-images.githubusercontent.com/26870220/143691299-f4112336-8608-4739-a248-20c79ea0b6e9.png)

After:
![image](https://user-images.githubusercontent.com/26870220/143691278-b78365a4-69fb-446f-ad9e-0021be250e59.png)
