### PR TITLE
Update background under context menu separator

### DIFF
--- a/src/nord.theme.json
+++ b/src/nord.theme.json
@@ -235,6 +235,9 @@
         "activeBackground": "#434c5e"
       }
     },
+    "PopupMenu": {
+      "background": "#323846"
+    },
     "ProgressBar": {
       "background": "#88c0d0",
       "failedColor": "#bf616a",


### PR DESCRIPTION
Update background under context menu separator to make sure, that it matches overall menu background.

**Before:**
![2022-01-06_10-50-02](https://user-images.githubusercontent.com/26870220/148356699-3bb27f5e-482e-4065-9812-5de378903587.png)


**After:**
![2022-01-06_10-51-25](https://user-images.githubusercontent.com/26870220/148356715-96b40f28-beae-473b-a288-11f0c544ccd6.png)

P.S. [JetBrains documentation](https://github.com/JetBrains/intellij-community/blob/idea/213.6461.79/platform/platform-resources/src/themes/metadata/JDK.themeMetadata.json#L726) mentions, that `PopupMenu.background` is responsible for "Background under the context **or the main menu** separators", but I haven't noticed any issues with main menu before/any changes after my commit.


Closes #190